### PR TITLE
Checkout redirect support when used within iframe

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -451,10 +451,16 @@ jQuery( function( $ ) {
 					success:	function( result ) {
 						try {
 							if ( 'success' === result.result ) {
+								var url = null;
 								if ( -1 === result.redirect.indexOf( 'https://' ) || -1 === result.redirect.indexOf( 'http://' ) ) {
-									window.location = result.redirect;
+									url = result.redirect;
 								} else {
-									window.location = decodeURI( result.redirect );
+									url = decodeURI( result.redirect );
+								}
+								if (window.self !== window.top) {
+									window.top.location.href = url;
+								} else {
+									window.location = url;
 								}
 							} else if ( 'failure' === result.result ) {
 								throw 'Result failure';


### PR DESCRIPTION
When the Wordpress action 'wc_send_frame_options_header' is removed for the purpose of making the checkout process embeddable within an iframe, redirection should occur in the parent window because of "Content Security Policy Level 3 - Frame Ancestors" restrictions that some payment providers are using. I was enforced to apply this fix for using mollie.com as my PSP.

You could potentially call this a security error, but when wc_send_frame_options_header is enabled, the checkout process won't be accessible at all within an iframe. So as far as i see it, this wouldn't cause security risks.

P.S. This is my first contribution to WooCommerce and the first time i worked with this plugin. Please be gentle :)